### PR TITLE
flask-cors 6.0.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,55 +1,60 @@
-{% set name = "Flask-Cors" %}
-{% set version = "3.0.10" %}
-{% set bundle = "tar.gz" %}
-{% set hash_type = "sha256" %}
-{% set hash = "b60839393f3b84a0f3746f6cdca56c1ad7426aa738b70d6c61375857823181de" %}
+{% set name = "flask-cors" %}
+{% set version = "6.0.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.{{ bundle }}
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
-  {{ hash_type }}: {{ hash }}
+  url: https://github.com/corydolphin/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
+  sha256: 229f273a5dd5ba6095ff162771d182fdc26070efa074fb83d54d4e83d0974405
 
 build:
   number: 0
-  noarch: python
-  script: python -m pip install --no-deps --ignore-installed .
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: True  # [py<39]
 
 requirements:
   host:
     - python
     - pip
-
+    - setuptools
+    - wheel
   run:
     - python
     - flask >=0.9
-    - six
+    - werkzeug >=0.7
 
 test:
+  source_files:
+    - tests
   imports:
     - flask_cors
     - flask_cors.core
     - flask_cors.decorator
     - flask_cors.extension
     - flask_cors.version
+  commands:
+    - pip check
+    - pytest -v tests
+  requires:
+    - pip
+    - pytest >=7.2.0
 
 about:
-  home: https://github.com/corydolphin/flask-cors
+  home: https://corydolphin.github.io/flask-cors
   license: MIT
   license_file: LICENSE
   license_family: MIT
-  summary: 'A Flask extension adding a decorator for CORS support'
+  summary: A Flask extension for handling Cross Origin Resource Sharing (CORS), making cross-origin AJAX possible.
   description: |
-    A Flask extension for handling Cross Origin Resource Sharing (CORS),
-    making cross-origin AJAX possible. This package exposes a Flask extension
-    which by default enables CORS support on all routes, for all origins and
-    methods.
-  doc_url: http://flask-cors.corydolphin.com/en/latest/
+    A Flask extension for handling Cross Origin Resource Sharing (CORS), making cross-origin AJAX possible.
+    This package has a simple philosophy: when you want to enable CORS, you wish to enable it for all use cases on a domain.
+    This means no mucking around with different allowed headers, methods, etc.
+    By default, submission of cookies across domains is disabled due to the security implications.
+    Please see the documentation for how to enable credential’ed requests, and please make sure you add some sort of CSRF protection before doing so!
+  doc_url: https://corydolphin.github.io/flask-cors
   dev_url: https://github.com/corydolphin/flask-cors
-  doc_source_url: https://github.com/corydolphin/flask-cors/blob/master/docs/index.rst
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,7 @@ source:
   url: https://github.com/corydolphin/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
   sha256: 229f273a5dd5ba6095ff162771d182fdc26070efa074fb83d54d4e83d0974405
   patches:
+    # Please keep checking until the upstream issue is fixed
     - patches/0001-fix-hardcoded-version.patch
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: https://github.com/corydolphin/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
   sha256: 229f273a5dd5ba6095ff162771d182fdc26070efa074fb83d54d4e83d0974405
+  patches:
+    - patches/0001-fix-hardcoded-version.patch
 
 build:
   number: 0
@@ -15,6 +17,9 @@ build:
   skip: True  # [py<39]
 
 requirements:
+  build:
+    - patch  # [not win]
+    - msys2-patch  # [win]
   host:
     - python
     - pip
@@ -36,6 +41,7 @@ test:
     - flask_cors.version
   commands:
     - pip check
+    - python -c "from importlib.metadata import version; print(version('{{ name|replace('-', '_') }}'))"
     - pytest -v tests
   requires:
     - pip
@@ -59,3 +65,6 @@ about:
 extra:
   recipe-maintainers:
     - pmlandwehr
+  skip-lints:
+    # use newer patcher for win
+    - patch_must_be_in_build

--- a/recipe/patches/0001-fix-hardcoded-version.patch
+++ b/recipe/patches/0001-fix-hardcoded-version.patch
@@ -1,0 +1,24 @@
+From edc4d3110656bc1d1a52b417174cc3bff18930c1 Mon Sep 17 00:00:00 2001
+From: Patryk Kups <pkups@anaconda.com>
+Date: Fri, 18 Jul 2025 18:20:25 +0200
+Subject: [PATCH] fix hardcoded version
+
+---
+ pyproject.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 765c5ec..ee4b335 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,6 +1,6 @@
+ [project]
+ name = "flask-cors"
+-version = "0.0.1"
++version = "6.0.1"
+ description = "A Flask extension simplifying CORS support"
+ authors = [{ name = "Cory Dolphin", email = "corydolphin@gmail.com" }]
+ readme = "README.rst"
+-- 
+2.39.5 (Apple Git-154)
+


### PR DESCRIPTION
flask-cors 6.0.1 

**Destination channel:** Defaults

### Links

- [PKG-8469]
- dev_url:        https://github.com/corydolphin/flask-cors/tree/6.0.1
- conda_forge:    https://github.com/conda-forge/flask-cors-feedstock
- pypi:           https://pypi.org/project/flask-cors/6.0.1
- pypi inspector: https://inspector.pypi.io/project/flask-cors/6.0.1

### Explanation of changes:

- new version number


[PKG-8469]: https://anaconda.atlassian.net/browse/PKG-8469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ