### PR TITLE
flask-cors 6.0.2 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "flask-cors" %}
-{% set version = "6.0.1" %}
+{% set version = "6.0.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/corydolphin/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 229f273a5dd5ba6095ff162771d182fdc26070efa074fb83d54d4e83d0974405
+  sha256: bab02db4299c1efd487d690a23b2a016b99a1e9e50149c5f911399d4141f8891
   patches:
     # Please keep checking until the upstream issue is fixed
     - patches/0001-fix-hardcoded-version.patch
@@ -18,9 +18,6 @@ build:
   skip: True  # [py<39]
 
 requirements:
-  build:
-    - patch  # [not win]
-    - msys2-patch  # [win]
   host:
     - python
     - pip

--- a/recipe/patches/0001-fix-hardcoded-version.patch
+++ b/recipe/patches/0001-fix-hardcoded-version.patch
@@ -1,6 +1,6 @@
-From edc4d3110656bc1d1a52b417174cc3bff18930c1 Mon Sep 17 00:00:00 2001
+From ce8f1b697fb64e839464757fafe5afde6743486d Mon Sep 17 00:00:00 2001
 From: Patryk Kups <pkups@anaconda.com>
-Date: Fri, 18 Jul 2025 18:20:25 +0200
+Date: Mon, 26 Jan 2026 09:59:21 +0100
 Subject: [PATCH] fix hardcoded version
 
 ---
@@ -8,17 +8,18 @@ Subject: [PATCH] fix hardcoded version
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/pyproject.toml b/pyproject.toml
-index 765c5ec..ee4b335 100644
+index 39a6c09..4215760 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
 @@ -1,6 +1,6 @@
  [project]
  name = "flask-cors"
 -version = "0.0.1"
-+version = "6.0.1"
++version = "6.0.2"
  description = "A Flask extension simplifying CORS support"
  authors = [{ name = "Cory Dolphin", email = "corydolphin@gmail.com" }]
  readme = "README.rst"
 -- 
 2.39.5 (Apple Git-154)
+
 


### PR DESCRIPTION
flask-cors 6.0.2 

**Destination channel:** Defaults

### Links

- [PKG-11460]
- dev_url:        https://github.com/corydolphin/flask-cors/tree/6.0.2
- conda_forge:    https://github.com/conda-forge/flask-cors-feedstock
- pypi:           https://pypi.org/project/flask-cors/6.0.2
- pypi inspector: https://inspector.pypi.io/project/flask-cors/6.0.2

### Explanation of changes:

- new version number


[PKG-11460]: https://anaconda.atlassian.net/browse/PKG-11460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ